### PR TITLE
Fix rendering of link markup with structured context

### DIFF
--- a/Renderer/RenderProcess.php
+++ b/Renderer/RenderProcess.php
@@ -256,7 +256,16 @@ class RenderProcess
         $renderedAttributes = [];
         for ($i = 0; $i < $numberOfAttributes; $i++)
         {
-            $renderedAttributes[] = $attributes[$i * 2] . '="' . \htmlspecialchars($attributes[($i * 2) + 1], \ENT_QUOTES) . '"';
+            $name = $attributes[$i * 2];
+            $value = $attributes[($i * 2) + 1];
+
+            // skip values, that are not strings (to be forward compatible with structured markup contexts)
+            if (!\is_string($value))
+            {
+                continue;
+            }
+
+            $renderedAttributes[] = $name . '="' . \htmlspecialchars($value, \ENT_QUOTES) . '"';
         }
 
         return "<{$tagName} " . \implode(" ", $renderedAttributes) .  ">";

--- a/tests/Renderer/RichTextRendererTest.php
+++ b/tests/Renderer/RichTextRendererTest.php
@@ -157,6 +157,19 @@ class RichTextRendererTest extends TestCase
                     ],
                 ],
                 '<img src="https://becklyn.com/example.png" alt="">',
+            ],
+            "ignore non-array attributes" => [
+                [
+                    "markups" => [
+                        ["a", ["href", "http://example.org", "rel", ["an" => "array"]]],
+                    ],
+                    "sections" => [
+                        [1, "p", [
+                            [0, [0], 1, "Link Text"],
+                        ]],
+                    ],
+                ],
+                '<p><a href="http://example.org">Link Text</a></p>'
             ]
         ];
     }


### PR DESCRIPTION
Links will now contain structured information about the type of link in the `"rel"` attribute.
This is just an array.

So when rendering we will omit this value for now.

In the future we will use these structured values to improve integration into the CMS.